### PR TITLE
FE-배송조회 페이지 추가

### DIFF
--- a/frontend/src/app/order/[order_number]/page.tsx
+++ b/frontend/src/app/order/[order_number]/page.tsx
@@ -25,8 +25,8 @@ export default function Page({params}: {params:Promise<{order_number:string}>}){
         total_price:1000,
         order_items:[
             {
-                order_id: 1,
-                dilivery_state: "배송중",
+                order_item_num: 1,
+                delivery_state: "배송중",
                 product_name: "스타버구 블렌드1",
                 product_eng_name: "Starbu9 Blend1",
                 price: 20000,
@@ -34,8 +34,8 @@ export default function Page({params}: {params:Promise<{order_number:string}>}){
                 count:1
               },
               {
-                order_id: 2,
-                dilivery_state: "배송중",
+                order_item_num: 2,
+                delivery_state: "배송중",
                 product_name: "스타버구 블렌드2",
                 product_eng_name: "Starbu9 Blend2",
                 price: 20000,
@@ -43,8 +43,8 @@ export default function Page({params}: {params:Promise<{order_number:string}>}){
                 count:1
               },
               {
-                order_id: 3,
-                dilivery_state: "배송중",
+                order_item_num: 3,
+                delivery_state: "배송중",
                 product_name: "스타버구 블렌드3",
                 product_eng_name: "Starbu9 Blend3",
                 price: 20000,
@@ -52,8 +52,8 @@ export default function Page({params}: {params:Promise<{order_number:string}>}){
                 count:1
               },
               {
-                order_id: 4,
-                dilivery_state: "배송중",
+                order_item_num: 4,
+                delivery_state: "배송중",
                 product_name: "스타버구 블렌드4",
                 product_eng_name: "Starbu9 Blend4",
                 price: 20000,
@@ -75,7 +75,7 @@ export default function Page({params}: {params:Promise<{order_number:string}>}){
                     <a className="ml-3">주문 번호 : {data.order_number}</a>
                 </div>
                 <ul className="mb-4">
-                    {data.order_items.map((e)=><OrderItem orderItem={e} key={e.order_id}></OrderItem>)}
+                    {data.order_items.map((e)=><OrderItem orderItem={e} key={e.order_item_num}></OrderItem>)}
                 </ul>
                 <a className="text-xl font-semibold mt-10 block">받는사람 정보</a>
                 <hr className="border-1"></hr>

--- a/frontend/src/app/order/delivery/[order_item_number]/page.tsx
+++ b/frontend/src/app/order/delivery/[order_item_number]/page.tsx
@@ -1,0 +1,46 @@
+
+
+function getMessage(delivery_state:string):string{
+    switch(delivery_state){
+        case "도착 완료":{
+            return "고객님이 주문하신 상품이 배송완료 되었습니다.";
+        }
+    }
+    return "";
+}
+
+export default function Page({params}: {params:Promise<{order_item_number:string}>}){
+    const data = {
+        "expected_delivery_date":"2/14",
+        "delivery_state":'도착 완료',
+        "email":"aaa@aa.com",
+        "address":"경기도 ..."
+    }
+    return (
+        <div className="flex justify-center text-black mt-10">
+            <div>
+                <p className="text-2xl font-bold">배송조회</p>
+                <div className="bg-gray-300 w-[800] border border-gray-400 px-10 py-3 mt-4">
+                    <div className="flex justify-center">
+                        <p className="block text-3xl">{data.expected_delivery_date}</p>
+                        <p className="block ml-5 text-3xl">{data.delivery_state}</p>
+
+                    </div>
+                    <p className="block justify-self-center">{getMessage(data.delivery_state)}</p>
+                </div>
+                <table className="flex justify-center mt-10">
+                    <tbody>
+                        <tr>
+                            <td className="text-gray-500 w-[100] text-lg">받는사람</td>
+                            <td className="text-lg">{data.email}</td>
+                        </tr>
+                        <tr>
+                            <td className="text-gray-500 w-[100] text-lg">받는주소</td>
+                            <td className="text-lg">{data.address}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/app/order/list/page.tsx
+++ b/frontend/src/app/order/list/page.tsx
@@ -3,8 +3,8 @@ import { useState, useEffect, useRef } from 'react';
 import Link from "next/link";
 
 interface OrderItem{
-    order_id:number,
-    dilivery_state:string,
+    order_item_num:number,
+    delivery_state:string,
     product_name:string,
     product_eng_name:string,
     price:number,
@@ -13,7 +13,6 @@ interface OrderItem{
 };
 
 interface Order{
-    num:number,
     order_number:string,
     order_address:string,
     total_price:number,
@@ -26,7 +25,7 @@ export function OrderItem({orderItem}:{orderItem:OrderItem}){
     return (
         <div className='border my-2 rounded-xl flex border-gray-300'>
             <div className='p-2'>
-                <a className='font-bold text-xl'>{orderItem.dilivery_state}</a>
+                <a className='font-bold text-xl'>{orderItem.delivery_state}</a>
                 <div className='flex'>
                     <img src={orderItem.image_url} className='w-[100] h-[100] object-cover'></img>
                     <div>
@@ -46,7 +45,7 @@ export function OrderItem({orderItem}:{orderItem:OrderItem}){
 
             <div className='border-l border-l-gray-300 ml-3 px-2'>
                 <div className='border rounded my-2 border-gray-300'>
-                    <a className='text-center block m-1 p-1'>배송 조회</a>
+                    <Link href={`/order/delivery/${orderItem.order_item_num}`} className='text-center block m-1 p-1'>배송 조회</Link>
                 </div>
                 <div className='border rounded my-2 border-gray-300'>
                     <a className='text-center block m-1 p-1'>교환, 반품 신청</a>
@@ -64,9 +63,9 @@ function OrderList({data}:{data:Order}){
         <div className='p-3 rounded-xl my-3 shadow-[0_0_5px_rgba(0,0,0,0.3)]'>
             <span className='flex justify-between'>
                 <a className='block text-xl font-bold'>{data.created_date} 주문</a>
-                <a className='text-blue-500 block' href={`/order/${data.order_number}`}>주문 상세 보기&gt;</a>
+                <Link className='text-blue-500 block' href={`/order/${data.order_number}`}>주문 상세 보기&gt;</Link>
             </span>
-            {data.order_items.map((e)=><OrderItem orderItem={e} key={e.order_id}></OrderItem>)}
+            {data.order_items.map((e)=><OrderItem orderItem={e} key={e.order_item_num}></OrderItem>)}
 
         </div>
     )
@@ -75,7 +74,6 @@ function OrderList({data}:{data:Order}){
 export default function page() {
     const datas:Order[] = [
         {
-            num:1,
             order_number:'111',
             total_price: 1000,
             order_address: "강남 프로그래머스",
@@ -83,8 +81,8 @@ export default function page() {
             created_date:"2025. 07. 16",
             order_items:[
                 {
-                    order_id: 1,
-                    dilivery_state: "배송중",
+                    order_item_num: 1,
+                    delivery_state: "배송중",
                     product_name: "스타버구 블렌드1",
                     product_eng_name: "Starbu9 Blend1",
                     price: 20000,
@@ -92,8 +90,8 @@ export default function page() {
                     count:1
                   },
                   {
-                    order_id: 2,
-                    dilivery_state: "배송중",
+                    order_item_num: 2,
+                    delivery_state: "배송중",
                     product_name: "스타버구 블렌드2",
                     product_eng_name: "Starbu9 Blend2",
                     price: 20000,
@@ -101,8 +99,8 @@ export default function page() {
                     count:1
                   },
                   {
-                    order_id: 3,
-                    dilivery_state: "배송중",
+                    order_item_num: 3,
+                    delivery_state: "배송중",
                     product_name: "스타버구 블렌드3",
                     product_eng_name: "Starbu9 Blend3",
                     price: 20000,
@@ -110,8 +108,8 @@ export default function page() {
                     count:1
                   },
                   {
-                    order_id: 4,
-                    dilivery_state: "배송중",
+                    order_item_num: 4,
+                    delivery_state: "배송중",
                     product_name: "스타버구 블렌드4",
                     product_eng_name: "Starbu9 Blend4",
                     price: 20000,
@@ -121,7 +119,6 @@ export default function page() {
             ]
         },
         {
-            num:2,
             order_number:'1233',
             total_price: 4000,
             order_address: "내 집",
@@ -129,8 +126,8 @@ export default function page() {
             created_date:"2025. 07. 15",
             order_items:[
                 {
-                    order_id: 1,
-                    dilivery_state: "배송중",
+                    order_item_num: 1,
+                    delivery_state: "배송중",
                     product_name: "스타버구 블렌드1",
                     product_eng_name: "Starbu9 Blend1",
                     price: 20000,
@@ -138,8 +135,8 @@ export default function page() {
                     count:1
                   },
                   {
-                    order_id: 2,
-                    dilivery_state: "배송중",
+                    order_item_num: 2,
+                    delivery_state: "배송중",
                     product_name: "스타버구 블렌드2",
                     product_eng_name: "Starbu9 Blend2",
                     price: 20000,
@@ -159,7 +156,7 @@ export default function page() {
             </div>
             <div className='flex justify-center mt-3'>
                 <ul>
-                    {datas.map((e)=><OrderList data={e} key={e.num}></OrderList>)}
+                    {datas.map((e)=><OrderList data={e} key={e.order_number}></OrderList>)}
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
<img width="1399" height="501" alt="image" src="https://github.com/user-attachments/assets/bec49a6a-3e78-4d19-ada4-4dd28d8a45d5" />
배송 조회 페이지를 만들었습니다.

<img width="795" height="453" alt="image" src="https://github.com/user-attachments/assets/256cdd00-70ed-4a4b-b0bf-89be31fe096c" />
배송조회 버튼을 통해 이동하게 만들었습니다.

더미 데이터의 이름을 약간 수정해뒀습니다.